### PR TITLE
Tidy unused imports, vars and extract nextTick method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import ReactDOM from 'react-dom'
 
 // DOM Testing Library utilities
 // note: if your framework does not apply updates to the DOM synchronously
-// then you can use the userEventAsync export in ./fire-event-async.js
+// then you can use the userEventAsync export in ./user-event-async.js
 // see hyperapp.test.js for an example of this.
 import {getQueriesForElement} from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'

--- a/hyperapp.test.js
+++ b/hyperapp.test.js
@@ -1,8 +1,8 @@
 /** @jsx hyperapp.h */
 import '@testing-library/jest-dom/extend-expect'
 import * as hyperapp from 'hyperapp/dist/hyperapp'
-import {userEventAsync} from './user-event-async'
-import {getQueriesForElement, waitFor} from '@testing-library/dom'
+import {userEventAsync, nextTick} from './user-event-async'
+import {getQueriesForElement} from '@testing-library/dom'
 
 export const state = {count: 0}
 
@@ -23,8 +23,7 @@ async function render({
   container = document.createElement('div'),
 }) {
   hyperapp.app(state, actions, view, container)
-  let count = 0
-  await new Promise(r => setTimeout(r, 0))
+  await nextTick()
   return {
     container,
     ...getQueriesForElement(container),
@@ -35,7 +34,7 @@ async function render({
 // export * from '@testing-library/dom'
 
 test('renders a counter', async () => {
-  const {getByText, getByTestId} = await render({state, view, actions})
+  const {getByText} = await render({state, view, actions})
   const counter = getByText('0')
   await userEventAsync.click(counter)
   expect(counter).toHaveTextContent('1')

--- a/svelte.test.js
+++ b/svelte.test.js
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom/extend-expect'
 import {userEventAsync} from './user-event-async'
 import {getQueriesForElement} from '@testing-library/dom'
-import * as svelte from 'svelte'
 import Counter from './counter.svelte'
 
 function render(Component) {

--- a/user-event-async.js
+++ b/user-event-async.js
@@ -2,13 +2,15 @@ import userEvent from '@testing-library/user-event'
 
 const userEventAsync = {}
 
+const nextTick = () => new Promise(r => setTimeout(r, 0))
+
 Object.entries(userEvent).reduce((obj, [key, val]) => {
   obj[key] = async (...args) => {
     const ret = val(...args)
-    await new Promise(r => setTimeout(r, 0))
+    await nextTick()
     return ret
   }
   return obj
 }, userEventAsync)
 
-export {userEventAsync}
+export {userEventAsync, nextTick}

--- a/vue.test.js
+++ b/vue.test.js
@@ -4,6 +4,7 @@ import {userEventAsync} from './user-event-async'
 import {getQueriesForElement} from '@testing-library/dom'
 
 Vue.config.productionTip = false
+Vue.config.devtools = false
 
 const Counter = {
   template: `


### PR DESCRIPTION
I noticed a few minor issues while reading through recent changes.

Notable: extracted idiom used in user-event-async AND `hyperapp.test.js` into a named `nextTick` function.

